### PR TITLE
Fix regex for console 'action' parsing

### DIFF
--- a/lib/GIR/Command.pm
+++ b/lib/GIR/Command.pm
@@ -26,7 +26,7 @@ sub parse
 		return _command_string('join', $1);
 	} elsif ($string =~ /^\s*say\s+(.+?)\s+(.+)$/i) {
 		return _command_string('say', $1, $2);
-	} elsif ($string =~ /^\s*action\s+(.+)\s+(.+)$/i) {
+	} elsif ($string =~ /^\s*action\s+(.+?)\s+(.+)$/i) {
 		return _command_string('action', $1, $2);
 	} elsif ($string =~ /^\s*discon(nect)?(\s+(.+))?$/i) {
 		return _command_string('discon', $3);


### PR DESCRIPTION
Fixes #29 

The regex for parsing `"action"` on the console was using greedy matching for both the channel and message parts, meaning that a multi-word action was parsing everything except the last word as the channel, which then got treated as a regular message to the channel instead of as an action. 